### PR TITLE
fix: order of migrations

### DIFF
--- a/src/migrations/0006_lonely_moira_mactaggert.sql
+++ b/src/migrations/0006_lonely_moira_mactaggert.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "user" ADD COLUMN "role" text NOT NULL;
+ALTER TABLE "user" ADD COLUMN "role" SET DEFAULT 'user';

--- a/src/migrations/0007_thick_black_knight.sql
+++ b/src/migrations/0007_thick_black_knight.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "user" ALTER COLUMN "role" SET DEFAULT 'user';
+ALTER TABLE "user" COLUMN "role" SET NOT NULL;


### PR DESCRIPTION
The order of migrations generated made it so the migrations didn’t implement. Just reversed the order, quick fix.